### PR TITLE
#3 Added no-cache headers when fetching FHIR resources

### DIFF
--- a/src/RemoteFhirResource.js
+++ b/src/RemoteFhirResource.js
@@ -44,6 +44,8 @@ class RemoteFhirResource extends Component {
       const response = await http.get(fhirServer + path + query, {
         headers: {
           Accept: 'application/fhir+json, application/fhir+xml;q=0.9',
+          Pragma: 'no-cache',
+          'Cache-Control': 'no-cache',
         },
       })
       const format = sniffFormat(response.headers['content-type'])


### PR DESCRIPTION
Added no-cache headers when fetching FHIR resources, since we don't currently handle 304 response

### Definition of Done

* [ x] Code has been peer reviewed
* [ x] Test coverage has been maintained or improved
* [ ] All tests pass within CI
* [ X] README is up to date
